### PR TITLE
feat: handle more config file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Options are merged from the following sources, in order of precedence:
 These options can be used with any command to configure the operation of `directus-sync`:
 
 - `-c, --config-path <configPath>`
-  Change the path to the config file. The default is `"./directus-sync.config.js"`.
+  Change the path to the config file. Default paths are: `./directus-sync.config.js`, `./directus-sync.config.cjs` or
+  `./directus-sync.config.json`.
 
 - `-d, --debug`  
   Display additional logging information. Useful for debugging or verifying what `directus-sync` is doing under the
@@ -124,7 +125,7 @@ These options can be used with any command to configure the operation of `direct
 The `directus-sync` CLI also supports a configuration file. This file is optional. If it is not provided, the CLI will
 use the default values for the options.
 
-The default path for the configuration file is `./directus-sync.config.js`. You can change this path using the
+The default paths for the configuration file are `./directus-sync.config.js`, `./directus-sync.config.cjs` or `./directus-sync.config.json`. You can change this path using the
 `--config-path` option.
 
 The configuration file can extend another configuration file using the `extends` property.

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,5 @@
 directus-config/
 README.md
-directus-sync.config.js
+directus-sync.config.*
+
+

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -8,4 +8,4 @@ test/
 example.env
 jest.config.js
 tsconfig.json
-directus-sync.config.js
+directus-sync.config.*

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 import { Option, program } from 'commander';
 import {
   DefaultConfig,
+  DefaultConfigPaths,
   disposeContext,
   initContext,
   logEndAndClose,
@@ -36,7 +37,9 @@ const directusPasswordOption = new Option(
 ).env('DIRECTUS_ADMIN_PASSWORD');
 const configPathOption = new Option(
   '-c, --config-path <configPath>',
-  `the path to the config file. Required for extended options (default "${DefaultConfig.configPath}")`,
+  `the path to the config file. Required for extended options (default paths: ${DefaultConfigPaths.join(
+    ', ',
+  )})`,
 );
 
 // Shared options

--- a/packages/cli/src/lib/services/config/default-config.ts
+++ b/packages/cli/src/lib/services/config/default-config.ts
@@ -1,8 +1,16 @@
 import { Options } from './interfaces';
 
-export const DefaultConfig: Partial<Options> = {
+export const DefaultConfigPaths = [
+  './directus-sync.config.js',
+  './directus-sync.config.cjs',
+  './directus-sync.config.json',
+];
+
+export const DefaultConfig: Pick<
+  Options,
+  'debug' | 'dumpPath' | 'collectionsPath' | 'snapshotPath' | 'split' | 'force'
+> = {
   // Global
-  configPath: './directus-sync.config.js',
   debug: false,
   // Pull, diff, push
   dumpPath: './directus-config',

--- a/packages/cli/src/lib/services/config/schema.ts
+++ b/packages/cli/src/lib/services/config/schema.ts
@@ -21,7 +21,7 @@ export const OptionsHooksSchema = z.object({
 
 export const OptionsFields = {
   // Global
-  configPath: z.string(),
+  configPath: z.string().optional(),
   debug: z.boolean(),
   directusUrl: z.string(),
   directusToken: z.string().optional(),


### PR DESCRIPTION
add `directus-sync.config.cjs` and `directus-sync.config.json` as default config file paths.