### PR TITLE
feat: allow Directus client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ module.exports = {
   directusToken: 'my-directus-token',
   directusEmail: 'admin@example.com', // ignored if directusToken is provided
   directusPassword: 'my-directus-password', // ignored if directusToken is provided
+  directusConfig: {
+    clientOptions: {},  // see https://docs.directus.io/guides/sdk/getting-started.html#polyfilling
+  }
   dumpPath: './directus-config',
   collectionsPath: 'collections',
   onlyCollections: ['roles', 'permissions', 'settings'],

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ module.exports = {
   directusPassword: 'my-directus-password', // ignored if directusToken is provided
   directusConfig: {
     clientOptions: {},  // see https://docs.directus.io/guides/sdk/getting-started.html#polyfilling
+    restConfig: {}, // see https://docs.directus.io/packages/@directus/sdk/rest/interfaces/RestConfig.html
   }
   dumpPath: './directus-config',
   collectionsPath: 'collections',

--- a/docs/troubleshooting/firewall-configurations/README.md
+++ b/docs/troubleshooting/firewall-configurations/README.md
@@ -1,3 +1,31 @@
+# Connect to Directus instance behind firewall
+
+If your Directus instance is protected by a firewall that requires additional headers or authorizations you can add them using the `directusConfig` setting:
+
+```js
+const addAuth = (request) => {
+    return ({
+        ...request,
+        headers: {
+            ...request.headers,
+            'Special-Access-Header': 'secret',
+        },
+    });
+};
+
+module.exports = {
+    directusConfig: {
+        clientOptions: {
+            globals: {
+                fetch: (input, init) => {
+                    return fetch(input, addAuth(init));
+                }
+            },
+        }
+    }
+};
+```
+
 # Synchronization Failures Due to Firewall Configurations
 
 Some requests made by `directus-sync`, particularly during the **diff** process, can be blocked by certain firewall
@@ -11,3 +39,4 @@ You should see this log message if this is the case:
 Check and adjust your firewall settings to ensure they don't block or interfere with directus-sync operations.
 This may involve whitelisting IP addresses or modifying rules to allow the necessary request patterns.
 More information in this [issue](https://github.com/tractr/directus-sync/issues/33).
+

--- a/packages/cli/src/lib/services/config/config.ts
+++ b/packages/cli/src/lib/services/config/config.ts
@@ -79,14 +79,15 @@ export class ConfigService {
   @Cacheable()
   getDirectusConfig(): DirectusConfigWithToken | DirectusConfigWithCredentials {
     const url = this.requireOptions('directusUrl');
+    const clientConfig = this.getOptions('directusConfig')?.clientOptions;
     const token = this.getOptions('directusToken');
     if (token) {
-      return { url, token };
+      return { url, token, clientConfig };
     }
 
     const email = this.requireOptions('directusEmail');
     const password = this.requireOptions('directusPassword');
-    return { url, email, password };
+    return { url, email, password, clientConfig };
   }
 
   @Cacheable()

--- a/packages/cli/src/lib/services/config/config.ts
+++ b/packages/cli/src/lib/services/config/config.ts
@@ -79,15 +79,17 @@ export class ConfigService {
   @Cacheable()
   getDirectusConfig(): DirectusConfigWithToken | DirectusConfigWithCredentials {
     const url = this.requireOptions('directusUrl');
-    const clientConfig = this.getOptions('directusConfig')?.clientOptions;
+    const directusConfig = this.getOptions('directusConfig');
+    const clientConfig = directusConfig?.clientOptions;
+    const restConfig = directusConfig?.restConfig;
     const token = this.getOptions('directusToken');
     if (token) {
-      return { url, token, clientConfig };
+      return { url, token, clientConfig, restConfig };
     }
 
     const email = this.requireOptions('directusEmail');
     const password = this.requireOptions('directusPassword');
-    return { url, email, password, clientConfig };
+    return { url, email, password, clientConfig, restConfig };
   }
 
   @Cacheable()

--- a/packages/cli/src/lib/services/config/interfaces.ts
+++ b/packages/cli/src/lib/services/config/interfaces.ts
@@ -5,6 +5,7 @@ import type {
   OptionsSchema,
   CollectionEnum,
   CollectionPreservableIdEnum,
+  ClientConfigSchema,
 } from './schema';
 import type { MigrationClient } from '../migration-client';
 import type { DirectusBaseType, Query } from '../collections';
@@ -55,6 +56,7 @@ export interface SnapshotHooks {
 
 interface DirectusConfigBase {
   url: string;
+  clientConfig: z.infer<typeof ClientConfigSchema> | undefined;
 }
 export interface DirectusConfigWithToken extends DirectusConfigBase {
   token: string;

--- a/packages/cli/src/lib/services/config/interfaces.ts
+++ b/packages/cli/src/lib/services/config/interfaces.ts
@@ -1,11 +1,12 @@
 import type { z } from 'zod';
-import type {
+import {
   ConfigFileOptionsSchema,
   OptionsFields,
   OptionsSchema,
   CollectionEnum,
   CollectionPreservableIdEnum,
   ClientConfigSchema,
+  RestConfigSchema,
 } from './schema';
 import type { MigrationClient } from '../migration-client';
 import type { DirectusBaseType, Query } from '../collections';
@@ -57,6 +58,7 @@ export interface SnapshotHooks {
 interface DirectusConfigBase {
   url: string;
   clientConfig: z.infer<typeof ClientConfigSchema> | undefined;
+  restConfig: z.infer<typeof RestConfigSchema> | undefined;
 }
 export interface DirectusConfigWithToken extends DirectusConfigBase {
   token: string;

--- a/packages/cli/src/lib/services/config/schema.ts
+++ b/packages/cli/src/lib/services/config/schema.ts
@@ -73,6 +73,12 @@ export const ClientConfigSchema = z.object({
     .optional(),
 });
 
+export const RestConfigSchema = z.object({
+  credentials: z.string().optional(),
+  onRequest: z.function().optional(),
+  onResponse: z.function().optional(),
+});
+
 export const OptionsFields = {
   // Global
   configPath: z.string().optional(),
@@ -84,6 +90,7 @@ export const OptionsFields = {
   directusConfig: z
     .object({
       clientOptions: ClientConfigSchema.optional(),
+      restConfig: RestConfigSchema.optional(),
     })
     .optional(),
   // Pull, diff, push
@@ -127,6 +134,7 @@ export const ConfigFileOptionsSchema = z.object({
   directusConfig: z
     .object({
       clientOptions: ClientConfigSchema.optional(),
+      restConfig: RestConfigSchema.optional(),
     })
     .optional(),
   // Dump config

--- a/packages/cli/src/lib/services/config/schema.ts
+++ b/packages/cli/src/lib/services/config/schema.ts
@@ -55,6 +55,24 @@ export const OptionsHooksSchema = z.object({
   snapshot: SnapshotHooksSchema.optional(),
 } satisfies { [key in z.infer<typeof CollectionEnum> | 'snapshot']: z.Schema });
 
+export const ClientConfigSchema = z.object({
+  globals: z
+    .object({
+      URL: z.instanceof(URL).optional(),
+      WebSocket: z.function().optional(),
+      fetch: z.function().returns(z.instanceof(Promise)).optional(),
+      logger: z
+        .object({
+          log: z.function(),
+          info: z.function(),
+          warn: z.function(),
+          error: z.function(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
 export const OptionsFields = {
   // Global
   configPath: z.string().optional(),
@@ -63,6 +81,11 @@ export const OptionsFields = {
   directusToken: z.string().optional(),
   directusEmail: z.string().optional(),
   directusPassword: z.string().optional(),
+  directusConfig: z
+    .object({
+      clientOptions: ClientConfigSchema.optional(),
+    })
+    .optional(),
   // Pull, diff, push
   dumpPath: z.string(),
   // Collections
@@ -101,6 +124,11 @@ export const ConfigFileOptionsSchema = z.object({
   directusToken: OptionsFields.directusToken.optional(),
   directusEmail: OptionsFields.directusEmail.optional(),
   directusPassword: OptionsFields.directusPassword.optional(),
+  directusConfig: z
+    .object({
+      clientOptions: ClientConfigSchema.optional(),
+    })
+    .optional(),
   // Dump config
   dumpPath: OptionsFields.dumpPath.optional(),
   // Collections config

--- a/packages/cli/src/lib/services/extension-client.ts
+++ b/packages/cli/src/lib/services/extension-client.ts
@@ -17,7 +17,9 @@ export abstract class ExtensionClient {
     options: RequestInit = {},
   ): Promise<T> {
     const { url, token } = await this.getUrlAndToken();
-    const response = await fetch(`${url}${this.extensionUri}${uri}`, {
+    const response = await (
+      await this.getFetch()
+    )(`${url}${this.extensionUri}${uri}`, {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
@@ -62,5 +64,11 @@ export abstract class ExtensionClient {
       throw new Error('Cannot get token from Directus');
     }
     return { url, token };
+  }
+
+  @Cacheable()
+  protected async getFetch() {
+    const directus = await this.migrationClient.get();
+    return directus.globals.fetch as typeof fetch;
   }
 }

--- a/packages/cli/src/lib/services/migration-client.ts
+++ b/packages/cli/src/lib/services/migration-client.ts
@@ -2,6 +2,7 @@ import {
   authentication,
   AuthenticationClient,
   clearCache,
+  ClientOptions,
   createDirectus,
   DirectusClient,
   readMe,
@@ -67,7 +68,10 @@ export class MigrationClient {
 
   protected async createClient() {
     const config = this.config.getDirectusConfig();
-    const client = createDirectus(config.url)
+    const client = createDirectus(
+      config.url,
+      config.clientConfig as ClientOptions | undefined,
+    )
       .with(rest())
       .with(authentication());
 

--- a/packages/cli/src/lib/services/migration-client.ts
+++ b/packages/cli/src/lib/services/migration-client.ts
@@ -8,6 +8,7 @@ import {
   readMe,
   rest,
   RestClient,
+  RestConfig,
 } from '@directus/sdk';
 import { Inject, Service } from 'typedi';
 import pino from 'pino';
@@ -72,7 +73,7 @@ export class MigrationClient {
       config.url,
       config.clientConfig as ClientOptions | undefined,
     )
-      .with(rest())
+      .with(rest(config.restConfig as RestConfig | undefined))
       .with(authentication());
 
     // If the token is already set, return it


### PR DESCRIPTION
Closes #84 

After some testing I realized that adding the `onRequest` hooks is not enough, because they are not used by the authentication extension. Instead the correct way is to use the client config itself to provide a `fetch` implementation, that adds the required headers (see https://docs.directus.io/guides/sdk/getting-started.html#polyfilling)

I still added the option to configure the rest client, but I am unsure if this is still necessary. (At least I don't need it any longer :wink: ).

Should I add an example for this to the firewall troubleshooting documentation?