### PR TITLE
feat: add --no-collections option

### DIFF
--- a/packages/cli/src/lib/program.ts
+++ b/packages/cli/src/lib/program.ts
@@ -130,6 +130,10 @@ export function createProgram() {
     '-o, --only-collections <onlyCollections>',
     `comma separated list of collections to include in the process (default to all)`,
   ).argParser(commaSeparatedList);
+  const noCollectionsOption = new Option(
+    '--no-collections',
+    `should pull and push the collections (default "${DefaultConfig.collections}")`,
+  );
   const preserveIdsOption = new Option(
     '--preserve-ids <preserveIds>',
     `comma separated list of collections that preserve their original ids (default to none). Use "*" or "all" to preserve all ids, if applicable.`,
@@ -178,6 +182,7 @@ export function createProgram() {
     .addOption(collectionsPathOption)
     .addOption(excludeCollectionsOption)
     .addOption(onlyCollectionsOption)
+    .addOption(noCollectionsOption)
     .addOption(preserveIdsOption)
     .addOption(snapshotPathOption)
     .addOption(noSnapshotOption)
@@ -195,6 +200,7 @@ export function createProgram() {
     .addOption(collectionsPathOption)
     .addOption(excludeCollectionsOption)
     .addOption(onlyCollectionsOption)
+    .addOption(noCollectionsOption)
     .addOption(snapshotPathOption)
     .addOption(noSnapshotOption)
     .addOption(noSplitOption)
@@ -208,6 +214,7 @@ export function createProgram() {
     .addOption(collectionsPathOption)
     .addOption(excludeCollectionsOption)
     .addOption(onlyCollectionsOption)
+    .addOption(noCollectionsOption)
     .addOption(preserveIdsOption)
     .addOption(snapshotPathOption)
     .addOption(noSnapshotOption)

--- a/packages/cli/src/lib/services/config/config.ts
+++ b/packages/cli/src/lib/services/config/config.ts
@@ -153,6 +153,10 @@ export class ConfigService {
 
   @Cacheable()
   getCollectionsToProcess() {
+    const collections = this.requireOptions('collections');
+    if (!collections) {
+      return [];
+    }
     const exclude = this.requireOptions('excludeCollections');
     const only = this.requireOptions('onlyCollections');
     const list = only.length > 0 ? only : CollectionsList;

--- a/packages/cli/src/lib/services/config/default-config.ts
+++ b/packages/cli/src/lib/services/config/default-config.ts
@@ -15,6 +15,7 @@ export const DefaultConfig: Pick<
   | 'collectionsPath'
   | 'excludeCollections'
   | 'onlyCollections'
+  | 'collections'
   | 'preserveIds'
   | 'snapshotPath'
   | 'snapshot'
@@ -34,6 +35,7 @@ export const DefaultConfig: Pick<
   collectionsPath: 'collections',
   excludeCollections: [],
   onlyCollections: [],
+  collections: true,
   preserveIds: [],
   // Snapshot
   snapshotPath: 'snapshot',

--- a/packages/cli/src/lib/services/config/schema.ts
+++ b/packages/cli/src/lib/services/config/schema.ts
@@ -103,6 +103,7 @@ export const OptionsFields = {
   collectionsPath: z.string(),
   excludeCollections: z.array(CollectionEnum).optional(),
   onlyCollections: z.array(CollectionEnum).optional(),
+  collections: z.boolean(),
   preserveIds: z.union([
     z.array(CollectionPreservableIdEnum).optional(),
     z.enum(['all', '*']),
@@ -150,6 +151,7 @@ export const ConfigFileOptionsSchema = z.object({
   collectionsPath: OptionsFields.collectionsPath.optional(),
   excludeCollections: OptionsFields.excludeCollections.optional(),
   onlyCollections: OptionsFields.onlyCollections.optional(),
+  collections: OptionsFields.collections.optional(),
   preserveIds: OptionsFields.preserveIds.optional(),
   // Snapshot config
   snapshotPath: OptionsFields.snapshotPath.optional(),

--- a/website/docs/features/configuration.mdx
+++ b/website/docs/features/configuration.mdx
@@ -52,6 +52,9 @@ These options can be used with any command to configure the operation of `direct
 - `-o, --only-collections <onlyCollections>`  
   Comma-separated list of directus collections to include during `pull` `push` or `diff` process.
 
+- `--no-collections`
+  Do not pull and push the Directus collections. By default, the collections are pulled and pushed.
+
 - `-x, --exclude-collections <excludeCollections>`  
   Comma-separated list of directus collections to exclude during `pull` `push` or `diff`. Can be used along
   with `only-collections`.
@@ -109,13 +112,14 @@ module.exports = {
   directusEmail: 'admin@example.com', // ignored if directusToken is provided
   directusPassword: 'my-directus-password', // ignored if directusToken is provided
   directusConfig: {
-    clientOptions: {},  // see https://docs.directus.io/guides/sdk/getting-started.html#polyfilling
+    clientOptions: {}, // see https://docs.directus.io/guides/sdk/getting-started.html#polyfilling
     restConfig: {}, // see https://docs.directus.io/packages/@directus/sdk/rest/interfaces/RestConfig.html
   },
   dumpPath: './directus-config',
   seedPath: './directus-config/seed',
   collectionsPath: 'collections',
   onlyCollections: ['roles', 'policies', 'permissions', 'settings'],
+  collections: true,
   excludeCollections: ['settings'],
   preserveIds: ['roles', 'panels'], // can be '*' or 'all' to preserve all ids, or an array of collections
   maxPushRetries: 20,

--- a/website/docs/help-outputs/diff.md
+++ b/website/docs/help-outputs/diff.md
@@ -4,6 +4,7 @@ Options:
   --collections-path <collectionPath>             the path for the collections dump, relative to the dump path (default "collections")
   -x, --exclude-collections <excludeCollections>  comma separated list of collections to exclude from the process (default to none)
   -o, --only-collections <onlyCollections>        comma separated list of collections to include in the process (default to all)
+  --no-collections                                should pull and push the Directus collections (default "true")
   --snapshot-path <snapshotPath>                  the path for the schema snapshot dump, relative to the dump path (default "snapshot")
   --no-snapshot                                   should pull and push the Directus schema (default "true")
   --no-split                                      should split the schema snapshot into multiple files (default "true")

--- a/website/docs/help-outputs/pull.md
+++ b/website/docs/help-outputs/pull.md
@@ -4,6 +4,7 @@ Options:
   --collections-path <collectionPath>             the path for the collections dump, relative to the dump path (default "collections")
   -x, --exclude-collections <excludeCollections>  comma separated list of collections to exclude from the process (default to none)
   -o, --only-collections <onlyCollections>        comma separated list of collections to include in the process (default to all)
+  --no-collections                                should pull and push the Directus collections (default "true")
   --preserve-ids <preserveIds>                    comma separated list of collections that preserve their original ids (default to none). Use "*" or "all" to preserve all ids, if applicable.
   --snapshot-path <snapshotPath>                  the path for the schema snapshot dump, relative to the dump path (default "snapshot")
   --no-snapshot                                   should pull and push the Directus schema (default "true")

--- a/website/docs/help-outputs/push.md
+++ b/website/docs/help-outputs/push.md
@@ -4,6 +4,7 @@ Options:
   --collections-path <collectionPath>             the path for the collections dump, relative to the dump path (default "collections")
   -x, --exclude-collections <excludeCollections>  comma separated list of collections to exclude from the process (default to none)
   -o, --only-collections <onlyCollections>        comma separated list of collections to include in the process (default to all)
+  --no-collections                                should pull and push the Directus collections (default "true")
   --preserve-ids <preserveIds>                    comma separated list of collections that preserve their original ids (default to none). Use "*" or "all" to preserve all ids, if applicable.
   --snapshot-path <snapshotPath>                  the path for the schema snapshot dump, relative to the dump path (default "snapshot")
   --no-snapshot                                   should pull and push the Directus schema (default "true")


### PR DESCRIPTION
Currently there is no proper way to sync only the schema (using `-o roles -x roles` is my current workaround it). This PR adds the flag `--no-collections` which can be used to sync only the schema.