### PR TITLE
fix(cli): splitting too long existing ids request in data-differ

### DIFF
--- a/packages/cli/src/lib/constants.ts
+++ b/packages/cli/src/lib/constants.ts
@@ -1,2 +1,3 @@
 export const LOGGER = 'logger';
 export const LOGGER_TRANSPORT = 'loggerTransport';
+export const DATA_DIFFER_MAX_IDS_PER_REQUEST = 100;

--- a/packages/cli/src/lib/helpers.ts
+++ b/packages/cli/src/lib/helpers.ts
@@ -132,3 +132,9 @@ export function getPinoTransport(): LoggerOptions['transport'] {
     },
   };
 }
+
+export function* chunks<T>(arr: T[], n: number): Generator<T[], void> {
+  for (let i = 0; i < arr.length; i += n) {
+    yield arr.slice(i, i + n);
+  }
+}


### PR DESCRIPTION
## Reason

In some cases, requesting too many IDs in a single call to `DataDiffer.getExistingIds()` results in an empty response. This leads to the removal of dangling items that actually exist.

For example, in my case, there are around 350 elements in the `operations` collection, and they aren’t handled correctly. I suspect the issue is caused by the URL being too long for the GET request initiated by the `directus-cli` package.

## Fix

As a solution, I split the array of requested IDs into chunks of 100 elements and make a separate request for each chunk.
