### PR TITLE
fix(cli): skipping mapping of dynamic IDs in DataMapper

### DIFF
--- a/packages/cli/src/lib/services/collections/base/data-mapper.ts
+++ b/packages/cli/src/lib/services/collections/base/data-mapper.ts
@@ -76,6 +76,12 @@ export abstract class DataMapper<T> {
     if (!this.syncIdToLocalIdMappers) {
       const callback =
         (idMapper: IdMapperClient, field: string) => async (id: DirectusId) => {
+          if (id.toString().trim().startsWith('{{')) {
+            this.logger.info(
+              `Value '${id}' for field '${field}' is dynamic, skipping mapping.`,
+            );
+            return id;
+          }
           const idMap = await idMapper.getBySyncId(id.toString());
           if (!idMap) {
             this.logger.warn(


### PR DESCRIPTION
## Problem

In some cases, we use dynamic values as flow IDs in operations—specifically in the "Trigger flow" node. This causes failures during ID mapping.

## Fix

Added a check for the presence of {{ in the base DataMapper service. If found, the value is returned as-is.