### PR TITLE
feat(cli): add `wait-server-ready` command to wait for Directus server to be ready

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+    
 npm run format

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-    
 npm run format

--- a/packages/cli/src/lib/commands/helpers/index.ts
+++ b/packages/cli/src/lib/commands/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './untrack';
 export * from './remove-permission-duplicates';
+export * from './wait-server-ready';

--- a/packages/cli/src/lib/commands/helpers/wait-server-ready.ts
+++ b/packages/cli/src/lib/commands/helpers/wait-server-ready.ts
@@ -1,0 +1,7 @@
+import { HelpersClient } from '../../services';
+import { Container } from 'typedi';
+
+export async function runWaitServerReady() {
+  const helpersClient = Container.get(HelpersClient);
+  await helpersClient.waitServerReady();
+}

--- a/packages/cli/src/lib/program.ts
+++ b/packages/cli/src/lib/program.ts
@@ -11,6 +11,7 @@ import {
   runPush,
   runRemovePermissionDuplicates,
   runUntrack,
+  runWaitServerReady,
 } from './index';
 import { runSeedPush, runSeedDiff } from './commands/seed';
 
@@ -285,9 +286,21 @@ export function createProgram() {
     .option(
       '--keep <keep>',
       `the permission to keep in case of conflict: "first" or "last" (default "${DefaultConfig.keep}")`,
-      'last',
     )
     .action(wrapAction(program, runRemovePermissionDuplicates));
+
+  helpers
+    .command('wait-server-ready')
+    .description('wait until the Directus server is ready (health endpoint)')
+    .option(
+      '--interval <interval>',
+      `seconds between checks (default "${DefaultConfig.interval}")`,
+    )
+    .option(
+      '--timeout <timeout>',
+      `timeout in seconds (default "${DefaultConfig.timeout}")`,
+    )
+    .action(wrapAction(program, runWaitServerReady));
 
   return program;
 }

--- a/packages/cli/src/lib/program.ts
+++ b/packages/cli/src/lib/program.ts
@@ -300,6 +300,10 @@ export function createProgram() {
       '--timeout <timeout>',
       `timeout in seconds (default "${DefaultConfig.timeout}")`,
     )
+    .option(
+      '--successes <successes>',
+      `number of consecutive successes required (default "${DefaultConfig.successes}")`,
+    )
     .action(wrapAction(program, runWaitServerReady));
 
   return program;

--- a/packages/cli/src/lib/services/config/config.ts
+++ b/packages/cli/src/lib/services/config/config.ts
@@ -136,6 +136,7 @@ export class ConfigService {
     return {
       interval: this.requireOptions('interval'),
       timeout: this.requireOptions('timeout'),
+      successes: this.requireOptions('successes'),
     };
   }
 

--- a/packages/cli/src/lib/services/config/config.ts
+++ b/packages/cli/src/lib/services/config/config.ts
@@ -132,6 +132,14 @@ export class ConfigService {
   }
 
   @Cacheable()
+  getWaitForServerReadyConfig() {
+    return {
+      interval: this.requireOptions('interval'),
+      timeout: this.requireOptions('timeout'),
+    };
+  }
+
+  @Cacheable()
   getConfigFileLoaderConfig() {
     return this.requireOptions('configPath');
   }

--- a/packages/cli/src/lib/services/config/default-config.ts
+++ b/packages/cli/src/lib/services/config/default-config.ts
@@ -29,6 +29,7 @@ export const DefaultConfig: Pick<
   | 'keep'
   | 'interval'
   | 'timeout'
+  | 'successes'
 > = {
   // Global
   debug: false,
@@ -60,4 +61,5 @@ export const DefaultConfig: Pick<
   // Helpers: wait for server ready
   interval: 5,
   timeout: 90,
+  successes: 1,
 };

--- a/packages/cli/src/lib/services/config/default-config.ts
+++ b/packages/cli/src/lib/services/config/default-config.ts
@@ -27,6 +27,8 @@ export const DefaultConfig: Pick<
   | 'seedPath'
   | 'force'
   | 'keep'
+  | 'interval'
+  | 'timeout'
 > = {
   // Global
   debug: false,
@@ -55,4 +57,7 @@ export const DefaultConfig: Pick<
   force: false,
   // Remove Permission Duplicates
   keep: 'last',
+  // Helpers: wait for server ready
+  interval: 5,
+  timeout: 90,
 };

--- a/packages/cli/src/lib/services/config/schema.ts
+++ b/packages/cli/src/lib/services/config/schema.ts
@@ -129,6 +129,7 @@ export const OptionsFields = {
   // Wait for server ready
   interval: z.number().or(z.string().transform(Number)).optional(),
   timeout: z.number().or(z.string().transform(Number)).optional(),
+  successes: z.number().or(z.string().transform(Number)).optional(),
   // Hooks
   hooks: OptionsHooksSchema.optional(),
   // Seed

--- a/packages/cli/src/lib/services/config/schema.ts
+++ b/packages/cli/src/lib/services/config/schema.ts
@@ -126,6 +126,9 @@ export const OptionsFields = {
   id: z.string().optional(),
   // Remove Permission Duplicates
   keep: z.enum(['first', 'last']).optional(),
+  // Wait for server ready
+  interval: z.number().or(z.string().transform(Number)).optional(),
+  timeout: z.number().or(z.string().transform(Number)).optional(),
   // Hooks
   hooks: OptionsHooksSchema.optional(),
   // Seed

--- a/packages/cli/src/lib/services/helpers-client.ts
+++ b/packages/cli/src/lib/services/helpers-client.ts
@@ -58,7 +58,7 @@ export class HelpersClient extends ExtensionClient {
 
     // Poll until ready or timeout
     while (Date.now() < endAt) {
-      const ready = await this.checkServerHealth().catch(() => false);
+      const ready = await this.checkServerStatus().catch(() => false);
       consecutiveSuccesses = ready ? consecutiveSuccesses + 1 : 0;
       if (consecutiveSuccesses >= successes) {
         this.logger.info('Server is ready');
@@ -71,12 +71,15 @@ export class HelpersClient extends ExtensionClient {
     throw new Error(`Timeout waiting for server to be ready after ${timeout}s`);
   }
 
-  protected async checkServerHealth() {
+  protected async checkServerStatus() {
     try {
       const client = await this.migrationClient.get();
       const result = await client.request(serverHealth());
-      return result?.status === 'ok';
-    } catch {
+      const isOk = result?.status === 'ok';
+      this.logger.debug(`Server status: ${result?.status}`);
+      return isOk;
+    } catch (e) {
+      this.logger.debug(`Error checking server status: ${e}`);
       return false;
     }
   }

--- a/packages/cli/src/lib/services/helpers-client.ts
+++ b/packages/cli/src/lib/services/helpers-client.ts
@@ -45,19 +45,22 @@ export class HelpersClient extends ExtensionClient {
   }
 
   async waitServerReady() {
-    const { interval, timeout } = this.config.getWaitForServerReadyConfig();
+    const { interval, timeout, successes } =
+      this.config.getWaitForServerReadyConfig();
     const intervalMs = interval * 1000;
     const timeoutMs = timeout * 1000;
     const endAt = Date.now() + timeoutMs;
+    let consecutiveSuccesses = 0;
 
     this.logger.info(
-      `Waiting for server to be ready (timeout ${timeout}s, interval ${interval}s)`,
+      `Waiting for server to be ready (timeout ${timeout}s, interval ${interval}s, successes ${successes})`,
     );
 
     // Poll until ready or timeout
     while (Date.now() < endAt) {
       const ready = await this.checkServerHealth().catch(() => false);
-      if (ready) {
+      consecutiveSuccesses = ready ? consecutiveSuccesses + 1 : 0;
+      if (consecutiveSuccesses >= successes) {
         this.logger.info('Server is ready');
         return;
       }

--- a/packages/cli/src/lib/services/helpers-client.ts
+++ b/packages/cli/src/lib/services/helpers-client.ts
@@ -3,6 +3,7 @@ import { MigrationClient } from './migration-client';
 import { Service } from 'typedi';
 import { ConfigService } from './config';
 import { LoggerService, Logger } from './logger';
+import { serverHealth } from '@directus/sdk';
 
 interface DeletedPermission {
   policy: string;
@@ -41,5 +42,39 @@ export class HelpersClient extends ExtensionClient {
     const { collection, id } = this.config.getUntrackConfig();
     await this.fetch(`/table/${collection}/local_id/${id}`, 'DELETE');
     this.logger.info(`Untracked ${collection} ${id}`);
+  }
+
+  async waitServerReady() {
+    const { interval, timeout } = this.config.getWaitForServerReadyConfig();
+    const intervalMs = interval * 1000;
+    const timeoutMs = timeout * 1000;
+    const endAt = Date.now() + timeoutMs;
+
+    this.logger.info(
+      `Waiting for server to be ready (timeout ${timeout}s, interval ${interval}s)`,
+    );
+
+    // Poll until ready or timeout
+    while (Date.now() < endAt) {
+      const ready = await this.checkServerHealth().catch(() => false);
+      if (ready) {
+        this.logger.info('Server is ready');
+        return;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw new Error(`Timeout waiting for server to be ready after ${timeout}s`);
+  }
+
+  protected async checkServerHealth() {
+    try {
+      const client = await this.migrationClient.get();
+      const result = await client.request(serverHealth());
+      return result?.status === 'ok';
+    } catch {
+      return false;
+    }
   }
 }

--- a/packages/cli/src/lib/services/helpers-client.ts
+++ b/packages/cli/src/lib/services/helpers-client.ts
@@ -79,7 +79,7 @@ export class HelpersClient extends ExtensionClient {
       this.logger.debug(`Server status: ${result?.status}`);
       return isOk;
     } catch (e) {
-      this.logger.debug(`Error checking server status: ${e}`);
+      this.logger.debug(`Error checking server status: ${e as Error}`);
       return false;
     }
   }

--- a/packages/e2e/spec/entrypoint.spec.ts
+++ b/packages/e2e/spec/entrypoint.spec.ts
@@ -40,6 +40,7 @@ import {
   removePermissionDuplicates,
 } from './permissions/index.js';
 import { removeTrackedItem } from './untrack/index.js';
+import { waitServerReady } from './server/index.js';
 import {
   createOperationsWithConflicts,
   updateOperationsWithConflicts,
@@ -117,6 +118,7 @@ describe('Tests entrypoint ->', () => {
   groupAndFieldNamesConflict(context);
 
   removeTrackedItem(context);
+  waitServerReady(context);
 
   seedPushOnEmptyInstance(context);
   seedUsers(context);

--- a/packages/e2e/spec/helpers/sdk/directus-sync.ts
+++ b/packages/e2e/spec/helpers/sdk/directus-sync.ts
@@ -69,6 +69,17 @@ export class DirectusSync {
     );
   }
 
+  waitServerReady(interval = 5, timeout = 90) {
+    return this.runCliCommand(
+      'helpers',
+      'wait-server-ready',
+      '--interval',
+      String(interval),
+      '--timeout',
+      String(timeout),
+    );
+  }
+
   seedPush(args?: string[]) {
     return this.runCliCommand(
       'seed',

--- a/packages/e2e/spec/helpers/sdk/directus-sync.ts
+++ b/packages/e2e/spec/helpers/sdk/directus-sync.ts
@@ -146,7 +146,7 @@ export class DirectusSync {
     Container.reset();
 
     // Remove the log file (disable next line for debugging)
-    // rmSync(logFilePath, { force: true });
+    fs.rmSync(logFilePath, { force: true });
 
     // Allow running another command
     this.running = false;

--- a/packages/e2e/spec/helpers/sdk/directus-sync.ts
+++ b/packages/e2e/spec/helpers/sdk/directus-sync.ts
@@ -69,7 +69,7 @@ export class DirectusSync {
     );
   }
 
-  waitServerReady(interval = 5, timeout = 90) {
+  waitServerReady(interval = 5, timeout = 90, successes = 1) {
     return this.runCliCommand(
       'helpers',
       'wait-server-ready',
@@ -77,6 +77,8 @@ export class DirectusSync {
       String(interval),
       '--timeout',
       String(timeout),
+      '--successes',
+      String(successes),
     );
   }
 

--- a/packages/e2e/spec/server/index.ts
+++ b/packages/e2e/spec/server/index.ts
@@ -1,0 +1,1 @@
+export * from './wait-server-ready.js';

--- a/packages/e2e/spec/server/wait-server-ready.ts
+++ b/packages/e2e/spec/server/wait-server-ready.ts
@@ -1,0 +1,11 @@
+import { Context, info } from '../helpers/index.js';
+
+export const waitServerReady = (context: Context) => {
+  it('should wait for the server to be ready', async () => {
+    const sync = await context.getSync('temp/wait-server-ready');
+
+    const output = await sync.waitServerReady(1, 10);
+
+    expect(output).toContain(info('[helpers-client] Server is ready'));
+  });
+};

--- a/website/docs/features/helpers.mdx
+++ b/website/docs/features/helpers.mdx
@@ -4,6 +4,7 @@ sidebar_position: 5
 
 import HelpUntrack from '../help-outputs/helpers-untrack.md';
 import HelpRemovePermissionDuplicates from '../help-outputs/helpers-remove-permission-duplicates.md';
+import HelpWaitServerReady from '../help-outputs/helpers-wait-server-ready.md';
 
 # Helpers
 
@@ -48,3 +49,17 @@ This command will keep the `last` (or `first`) permission found and remove the o
 **Available Options**
 
 <HelpRemovePermissionDuplicates />
+
+## Wait for Server Ready
+
+Wait until the Directus server reports healthy on its health endpoint. Polls every X seconds until ready or until the timeout is reached.
+
+```shell
+npx directus-sync helpers wait-server-ready --interval <seconds> --timeout <seconds>
+```
+
+By default, `interval` is 5 seconds and `timeout` is 90 seconds.
+
+**Available Options**
+
+<HelpWaitServerReady />

--- a/website/docs/help-outputs/helpers-remove-permission-duplicates.md
+++ b/website/docs/help-outputs/helpers-remove-permission-duplicates.md
@@ -1,6 +1,6 @@
 ```text
 Options:
   --keep <keep>  the permission to keep in case of conflict: "first" or "last"
-                 (default "last") (default: "last")
+                 (default "last")
   -h, --help     display help for command
 ```

--- a/website/docs/help-outputs/helpers-wait-server-ready.md
+++ b/website/docs/help-outputs/helpers-wait-server-ready.md
@@ -1,0 +1,6 @@
+```text
+Options:
+  --interval <interval>  seconds between checks (default "5")
+  --timeout <timeout>    timeout in seconds (default "90")
+  -h, --help             display help for command
+```

--- a/website/docs/help-outputs/helpers-wait-server-ready.md
+++ b/website/docs/help-outputs/helpers-wait-server-ready.md
@@ -1,6 +1,8 @@
 ```text
 Options:
-  --interval <interval>  seconds between checks (default "5")
-  --timeout <timeout>    timeout in seconds (default "90")
-  -h, --help             display help for command
+  --interval <interval>    seconds between checks (default "5")
+  --timeout <timeout>      timeout in seconds (default "90")
+  --successes <successes>  number of consecutive successes required (default
+                           "1")
+  -h, --help               display help for command
 ```

--- a/website/scripts/update-help-outputs.mjs
+++ b/website/scripts/update-help-outputs.mjs
@@ -14,6 +14,10 @@ const commands = [
     command: 'helpers remove-permission-duplicates',
     filename: 'helpers-remove-permission-duplicates.md',
   },
+  {
+    command: 'helpers wait-server-ready',
+    filename: 'helpers-wait-server-ready.md',
+  },
 ];
 const outputDir = path.join('docs/help-outputs');
 


### PR DESCRIPTION
- Introduced a new command to wait for the Directus server to be ready, with configurable interval and timeout options.
- Updated the configuration service to include default values for interval and timeout.
- Added documentation for the new command and its options.
- Enhanced the helpers client to support server readiness checks.