### PR TITLE
fix: respect collections: false from config file (#198)

### DIFF
--- a/packages/cli/src/lib/program.ts
+++ b/packages/cli/src/lib/program.ts
@@ -26,6 +26,9 @@ function cleanProgramOptions(programOptions: Record<string, unknown>) {
  * Remove some default values from the command options that overrides the config file
  */
 function cleanCommandOptions(commandOptions: Record<string, unknown>) {
+  if (commandOptions.collections === true) {
+    delete commandOptions.collections;
+  }
   if (commandOptions.snapshot === true) {
     delete commandOptions.snapshot;
   }

--- a/packages/e2e/configs/no-collections-config-file/directus-sync.config.cjs
+++ b/packages/e2e/configs/no-collections-config-file/directus-sync.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  collections: false,
+};

--- a/packages/e2e/spec/entrypoint.spec.ts
+++ b/packages/e2e/spec/entrypoint.spec.ts
@@ -33,6 +33,7 @@ import {
   includeSomeCollections,
   noSnapshot,
   noCollections,
+  noCollectionsConfigFile,
 } from './exclude-include/index.js';
 import {
   insertDuplicatedPermissions,
@@ -108,6 +109,7 @@ describe('Tests entrypoint ->', () => {
   includeSomeCollections(context);
   noSnapshot(context);
   noCollections(context);
+  noCollectionsConfigFile(context);
 
   configPathInfo(context);
 

--- a/packages/e2e/spec/exclude-include/index.ts
+++ b/packages/e2e/spec/exclude-include/index.ts
@@ -2,3 +2,4 @@ export * from './exclude-some-collections.js';
 export * from './include-some-collections.js';
 export * from './no-snapshot.js';
 export * from './no-collections.js';
+export * from './no-collections-config-file.js';

--- a/packages/e2e/spec/exclude-include/no-collections-config-file.ts
+++ b/packages/e2e/spec/exclude-include/no-collections-config-file.ts
@@ -1,0 +1,93 @@
+import {
+  Context,
+  createOneItemInEachSystemCollection,
+  debug,
+  getDumpedSystemCollectionsContents,
+  getSystemCollectionsNames,
+  info,
+} from '../helpers/index.js';
+
+export const noCollectionsConfigFile = (context: Context) => {
+  it('should not pull any collections when collections: false is set in the config file', async () => {
+    // Init sync client with a config file that disables collections
+    const sync = await context.getSync(
+      'temp/no-collections-config-file',
+      'no-collections-config-file/directus-sync.config.cjs',
+    );
+    const directus = context.getDirectus();
+
+    const systemCollections = getSystemCollectionsNames();
+
+    // --------------------------------------------------------------------
+    // Create content using Directus SDK
+    const client = directus.get();
+    await createOneItemInEachSystemCollection(client);
+
+    // --------------------------------------------------------------------
+    // Pull the content from Directus (no CLI flag, only config file)
+    const output = await sync.pull();
+
+    // --------------------------------------------------------------------
+    // Check if the logs do not report any content being pulled
+    for (const collection of systemCollections) {
+      expect(output)
+        .withContext(collection)
+        .not.toContain(debug(`[${collection}] Pulled 0 items.`));
+      expect(output)
+        .withContext(collection)
+        .not.toContain(debug(`[${collection}] Pulled 1 items.`));
+    }
+
+    // --------------------------------------------------------------------
+    // Check that no sync IDs were created
+    for (const collection of systemCollections) {
+      expect((await directus.getSyncIdMaps(collection)).length)
+        .withContext(collection)
+        .toBe(0);
+    }
+
+    // --------------------------------------------------------------------
+    // Check that no collections were dumped
+    const collections = getDumpedSystemCollectionsContents(sync.getDumpPath());
+    for (const collection of systemCollections) {
+      expect(collections[collection]).withContext(collection).toBeUndefined();
+    }
+  });
+
+  it('should not push any collections when collections: false is set in the config file', async () => {
+    // Init sync client with a config file that disables collections
+    const sync = await context.getSync(
+      'sources/one-item-per-collection',
+      'no-collections-config-file/directus-sync.config.cjs',
+    );
+    const directus = context.getDirectus();
+    const systemCollections = getSystemCollectionsNames();
+
+    // --------------------------------------------------------------------
+    // Push the data to Directus (no CLI flag, only config file)
+    const beforePushDate = new Date();
+    const output = await sync.push();
+
+    // --------------------------------------------------------------------
+    // Check if the logs do not report any content being pushed
+    for (const collection of systemCollections) {
+      expect(output)
+        .withContext(collection)
+        .not.toContain(info(`[${collection}] Created 1 items`));
+      expect(output)
+        .withContext(collection)
+        .not.toContain(debug(`[${collection}] Created 0 items`));
+    }
+
+    // --------------------------------------------------------------------
+    // Ensure that no activities were created
+    const activities = await directus.getActivities(beforePushDate);
+    for (const collection of systemCollections) {
+      const created = activities.filter(
+        (a) =>
+          a.action === 'create' && a.collection === `directus_${collection}`,
+      );
+      expect(created.length).withContext(collection).toBe(0);
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- Fixes tractr/directus-sync#198: `collections: false` (and equivalents) set in `directus-sync.config.cjs` were silently ignored because the `--no-collections` commander flag injects a default `collections: true` into the command options, which then takes precedence over the config file in the merge order.
- Strip the `collections: true` default from command options in `cleanCommandOptions`, mirroring what is already done for `snapshot`, `split`, and `specs`.
- Add e2e coverage that drives the option only via a config file (no CLI flag), for both `pull` and `push`, modeled on the existing `no-collections` tests.

## Test plan
- [x] CI runs the new `noCollectionsConfigFile` e2e tests (pull + push) and they pass.
- [x] Existing `noCollections` CLI-flag tests still pass (no regression for the `--no-collections` path).