### PR TITLE
fix: filter user attached policy accesses on pull

### DIFF
--- a/packages/cli/src/lib/services/collections/policies/data-client.ts
+++ b/packages/cli/src/lib/services/collections/policies/data-client.ts
@@ -41,8 +41,9 @@ export class PoliciesDataClient extends DataClient<DirectusPolicy> {
     // When role-policy attachments sync is disabled, omit the roles fields
     // entirely from the dump so they are neither tracked nor diffed.
     // See https://github.com/tractr/directus-sync/issues/199
+    // Include roles.user so we can detect and skip user-attached accesses.
     const extraFields = this.config.shouldSyncPolicyRoles()
-      ? ['*', 'roles.role', 'roles.sort']
+      ? ['*', 'roles.role', 'roles.user', 'roles.sort']
       : ['*'];
     return readPolicies(
       deepmerge<Query<BaseDirectusPolicy>>(query, {

--- a/packages/cli/src/lib/services/collections/policies/data-mapper.ts
+++ b/packages/cli/src/lib/services/collections/policies/data-mapper.ts
@@ -33,12 +33,12 @@ export class PoliciesDataMapper extends DataMapper<DirectusPolicy> {
   ): Promise<WithSyncIdAndWithoutId<DirectusPolicy>[]> {
     const filtered = items.map((item) =>
       Array.isArray(item.roles)
-        ? {
+        ? ({
             ...item,
             roles: (item.roles as Partial<DirectusPolicyAccess>[]).filter(
               (a) => !(a.role === null && a.user != null),
             ),
-          } as WithSyncIdAndWithoutId<DirectusPolicy>
+          } as WithSyncIdAndWithoutId<DirectusPolicy>)
         : item,
     );
     return super.mapIdsToSyncIdAndRemoveIgnoredFields(filtered);

--- a/packages/cli/src/lib/services/collections/policies/data-mapper.ts
+++ b/packages/cli/src/lib/services/collections/policies/data-mapper.ts
@@ -38,7 +38,7 @@ export class PoliciesDataMapper extends DataMapper<DirectusPolicy> {
             roles: (item.roles as Partial<DirectusPolicyAccess>[]).filter(
               (a) => !(a.role === null && a.user != null),
             ),
-          }
+          } as WithSyncIdAndWithoutId<DirectusPolicy>
         : item,
     );
     return super.mapIdsToSyncIdAndRemoveIgnoredFields(filtered);

--- a/packages/cli/src/lib/services/collections/policies/data-mapper.ts
+++ b/packages/cli/src/lib/services/collections/policies/data-mapper.ts
@@ -1,8 +1,8 @@
-import { DataMapper, Field, IdMappers } from '../base';
+import { DataMapper, Field, IdMappers, WithSyncIdAndWithoutId } from '../base';
 import { Container, Service } from 'typedi';
 import { LoggerService } from '../../logger';
 import { POLICIES_COLLECTION } from './constants';
-import { DirectusPolicy } from './interfaces';
+import { DirectusPolicy, DirectusPolicyAccess } from './interfaces';
 import { RolesIdMapperClient } from '../roles';
 import { ConfigService } from '../../config';
 
@@ -26,5 +26,21 @@ export class PoliciesDataMapper extends DataMapper<DirectusPolicy> {
       this.fieldsToIgnore = ['users', 'permissions', 'roles'];
       this.idMappers = {};
     }
+  }
+
+  async mapIdsToSyncIdAndRemoveIgnoredFields(
+    items: WithSyncIdAndWithoutId<DirectusPolicy>[],
+  ): Promise<WithSyncIdAndWithoutId<DirectusPolicy>[]> {
+    const filtered = items.map((item) =>
+      Array.isArray(item.roles)
+        ? {
+            ...item,
+            roles: (item.roles as Partial<DirectusPolicyAccess>[]).filter(
+              (a) => !(a.role === null && a.user != null),
+            ),
+          }
+        : item,
+    );
+    return super.mapIdsToSyncIdAndRemoveIgnoredFields(filtered);
   }
 }

--- a/packages/cli/src/lib/services/collections/policies/id-mapper-client.ts
+++ b/packages/cli/src/lib/services/collections/policies/id-mapper-client.ts
@@ -120,6 +120,9 @@ export class PoliciesIdMapperClient extends IdMapperClient {
           filter: {
             _and: [
               { roles: { role: { _null: true } } },
+              // Exclude user-attached accesses (role=null, user=uuid) so they
+              // are not mistaken for the public policy access (role=null, user=null).
+              { roles: { user: { _null: true } } },
               {
                 _or: [
                   { roles: { sort: { _eq: 1 } } },

--- a/packages/e2e/dumps/sources/default-updated/collections/policies.json
+++ b/packages/e2e/dumps/sources/default-updated/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/dependencies-operations-reversed/collections/policies.json
+++ b/packages/e2e/dumps/sources/dependencies-operations-reversed/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/dependencies-operations/collections/policies.json
+++ b/packages/e2e/dumps/sources/dependencies-operations/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/dependencies-settings-default-folder/collections/policies.json
+++ b/packages/e2e/dumps/sources/dependencies-settings-default-folder/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/dependencies-settings-default-role/collections/policies.json
+++ b/packages/e2e/dumps/sources/dependencies-settings-default-role/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/empty-collections/collections/policies.json
+++ b/packages/e2e/dumps/sources/empty-collections/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/group-and-field-names-conflict/collections/policies.json
+++ b/packages/e2e/dumps/sources/group-and-field-names-conflict/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/one-item-per-collection-updated/collections/policies.json
+++ b/packages/e2e/dumps/sources/one-item-per-collection-updated/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],
@@ -42,6 +44,7 @@
     "roles": [
       {
         "role": "52183adc-3e8e-4746-abd2-ee8dfc58efd5",
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/one-item-per-collection/collections/policies.json
+++ b/packages/e2e/dumps/sources/one-item-per-collection/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],
@@ -42,6 +44,7 @@
     "roles": [
       {
         "role": "52183adc-3e8e-4746-abd2-ee8dfc58efd5",
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/operations-dynamic-flow-id/collections/policies.json
+++ b/packages/e2e/dumps/sources/operations-dynamic-flow-id/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/public-permissions/collections/policies.json
+++ b/packages/e2e/dumps/sources/public-permissions/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/seed-basic/collections/policies.json
+++ b/packages/e2e/dumps/sources/seed-basic/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/seed-files/collections/policies.json
+++ b/packages/e2e/dumps/sources/seed-files/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/seed-users/collections/policies.json
+++ b/packages/e2e/dumps/sources/seed-users/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/snapshot-with-custom-model/collections/policies.json
+++ b/packages/e2e/dumps/sources/snapshot-with-custom-model/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],
@@ -42,6 +44,7 @@
     "roles": [
       {
         "role": "5acb1b4a-64bb-484a-9e76-76ed9b13251e",
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/dumps/sources/snapshot-with-sync-id-map/collections/policies.json
+++ b/packages/e2e/dumps/sources/snapshot-with-sync-id-map/collections/policies.json
@@ -10,6 +10,7 @@
     "roles": [
       {
         "role": "_sync_default_admin_role",
+        "user": null,
         "sort": null
       }
     ],
@@ -26,6 +27,7 @@
     "roles": [
       {
         "role": null,
+        "user": null,
         "sort": 1
       }
     ],

--- a/packages/e2e/spec/helpers/sdk/interfaces/policy.ts
+++ b/packages/e2e/spec/helpers/sdk/interfaces/policy.ts
@@ -3,6 +3,7 @@ export type FixPolicy<T> = Omit<T, 'roles'> & {
   name: string;
   roles: {
     role: string;
+    user: null;
     sort: number;
   }[];
 };

--- a/packages/e2e/spec/helpers/utils/batch.ts
+++ b/packages/e2e/spec/helpers/utils/batch.ts
@@ -110,7 +110,7 @@ export async function createOneItemInEachSystemCollection(
   const [policy] = (await client.request(
     readPolicies({
       filter: { id: policyRaw.id },
-      fields: ['*', 'roles.role', 'roles.sort'],
+      fields: ['*', 'roles.role', 'roles.user', 'roles.sort'],
       // Todo: remove this once it is fixed in the SDK
     } as Query<Schema, DirectusPolicy<Schema>>),
   )) as unknown as FixPolicy<DirectusPolicy<Schema>>[];

--- a/packages/e2e/spec/pull-diff-push/pull-basic.ts
+++ b/packages/e2e/spec/pull-diff-push/pull-basic.ts
@@ -144,6 +144,7 @@ export const pullBasic = (context: Context) => {
           policy.roles.map(async (role) => {
             return {
               role: (await directus.getByLocalId('roles', role.role)).sync_id,
+              user: role.user,
               sort: role.sort,
             };
           }),

--- a/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
+++ b/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
@@ -87,10 +87,10 @@ export const pushWithUserPolicyAssignment = (context: Context) => {
 
     // Read the dump — user-attached accesses (role=null, user=uuid) must be absent
     const { policies } = getDumpedSystemCollectionsContents(sync.getDumpPath());
-    type DumpAccess = { role: string | null; user?: string | null };
+    interface DumpAccess { role: string | null; user?: string | null }
     const userAttachedInDump = (policies ?? []).flatMap(
       (p: Record<string, unknown>) =>
-        ((p.roles as unknown as DumpAccess[] | undefined) ?? []).filter(
+        ((p.roles as DumpAccess[] | undefined) ?? []).filter(
           (r) => r.role === null && r.user != null,
         ),
     );

--- a/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
+++ b/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
@@ -1,8 +1,4 @@
-import {
-  createUser,
-  DirectusPolicy,
-  readUser,
-} from '@directus/sdk';
+import { createUser, DirectusPolicy, readUser } from '@directus/sdk';
 import {
   Context,
   getDumpedSystemCollectionsContents,
@@ -94,11 +90,10 @@ export const pushWithUserPolicyAssignment = (context: Context) => {
     type DumpAccess = { role: string | null; user?: string | null };
     const userAttachedInDump = (policies ?? []).flatMap(
       (p: Record<string, unknown>) =>
-        (
-          (p.roles as unknown as DumpAccess[] | undefined) ?? []
-        ).filter((r) => r.role === null && r.user != null),
+        ((p.roles as unknown as DumpAccess[] | undefined) ?? []).filter(
+          (r) => r.role === null && r.user != null,
+        ),
     );
     expect(userAttachedInDump.length).toBe(0);
   });
-
 };

--- a/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
+++ b/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
@@ -87,7 +87,10 @@ export const pushWithUserPolicyAssignment = (context: Context) => {
 
     // Read the dump — user-attached accesses (role=null, user=uuid) must be absent
     const { policies } = getDumpedSystemCollectionsContents(sync.getDumpPath());
-    interface DumpAccess { role: string | null; user?: string | null }
+    interface DumpAccess {
+      role: string | null;
+      user?: string | null;
+    }
     const userAttachedInDump = (policies ?? []).flatMap(
       (p: Record<string, unknown>) =>
         ((p.roles as DumpAccess[] | undefined) ?? []).filter(

--- a/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
+++ b/packages/e2e/spec/pull-diff-push/push-with-user-policy-assignment.ts
@@ -1,5 +1,15 @@
-import { createUser, DirectusPolicy, readUser } from '@directus/sdk';
-import { Context, newPolicy, newRole, Schema } from '../helpers/index.js';
+import {
+  createUser,
+  DirectusPolicy,
+  readUser,
+} from '@directus/sdk';
+import {
+  Context,
+  getDumpedSystemCollectionsContents,
+  newPolicy,
+  newRole,
+  Schema,
+} from '../helpers/index.js';
 
 export const pushWithUserPolicyAssignment = (context: Context) => {
   it('should preserve user policy assignments after push', async () => {
@@ -54,4 +64,41 @@ export const pushWithUserPolicyAssignment = (context: Context) => {
     );
     expect(finalUser.policies.map(extractPolicyId)).toContain(policy.id);
   });
+
+  it('should not include user-attached accesses in dump on pull', async () => {
+    const sync = await context.getSync(
+      'temp/push-with-user-policy-assignment-pull-filter',
+    );
+    const directus = context.getDirectus();
+    const client = directus.get();
+
+    // Create a role and policy
+    const role = await newRole(client);
+    const policy = await newPolicy(client, role.id);
+
+    // Assign the policy directly to a user (creates role=null, user=uuid access)
+    await client.request(
+      createUser({
+        email: `user-policy-pull-${Date.now()}@example.com`,
+        password: 'password123',
+        role: role.id,
+        policies: [{ policy: policy.id, role: null, sort: 1 }],
+      } as Partial<DirectusPolicy<Schema>>),
+    );
+
+    // Pull
+    await sync.pull();
+
+    // Read the dump — user-attached accesses (role=null, user=uuid) must be absent
+    const { policies } = getDumpedSystemCollectionsContents(sync.getDumpPath());
+    type DumpAccess = { role: string | null; user?: string | null };
+    const userAttachedInDump = (policies ?? []).flatMap(
+      (p: Record<string, unknown>) =>
+        (
+          (p.roles as unknown as DumpAccess[] | undefined) ?? []
+        ).filter((r) => r.role === null && r.user != null),
+    );
+    expect(userAttachedInDump.length).toBe(0);
+  });
+
 };


### PR DESCRIPTION
Closes #170
                                                                                                                  
## Problem

When a policy is assigned directly to a user (rather than via a role), Directus creates an `access` record with `role = null` and `user = <uuid>`. Two bugs stemmed from this:
1. **Incorrect public policy detection** — the public policy is identified by `role = null` (and `user = null`). User-attached accesses also have `role = null`, causing them to be mistakenly matched as the public policy.
2. **Polluted dump on pull** — user-attached accesses were included in the policy dump, which is incorrect since they represent user-specific runtime state, not sync-able configuration.

## Changes

- **`policies/id-mapper-client.ts`** — tightened the public policy filter to also require `user = null`, so user-attached accesses (`role = null, user = uuid`) are no longer mistaken for the public policy.
- **`policies/data-client.ts`** — added `roles.user` to the fetched fields so user-attached accesses can be identified during pull.
- **`policies/data-mapper.ts`** — overrides `mapIdsToSyncIdAndRemoveIgnoredFields` to strip any access entries where `role = null` and `user != null` before they reach the dump.
- **`e2e/push-with-user-policy-assignment.ts`** — adds a new test asserting that user-attached accesses are absent from the pulled dump.